### PR TITLE
Expose underlying Link API

### DIFF
--- a/src/components/AnchorLink.js
+++ b/src/components/AnchorLink.js
@@ -13,7 +13,8 @@ export function AnchorLink({
   title,
   children,
   className,
-  stripHash = false
+  stripHash = false,
+  ...additionalLinkProps
 }) {
   const linkProps = {
     to: stripHash ? stripHashedLocation(to) : to,
@@ -27,7 +28,7 @@ export function AnchorLink({
   if (title) linkProps.title = title;
   if (className) linkProps.className = className;
 
-  return <Link {...linkProps}>{Boolean(children) ? children : title}</Link>;
+  return <Link {...linkProps, ...additionalLinkProps}>{Boolean(children) ? children : title}</Link>;
 }
 
 AnchorLink.propTypes = anchorLinkTypes;


### PR DESCRIPTION
Motivated by the desire to utilize gatsby's underlying `<Link>` API, such
as `state` or `replace`. See: https://www.gatsbyjs.org/docs/gatsby-link/ or
taken from code:

```ts
export interface GatsbyLinkProps<TState> extends LinkProps<TState> {
  /** A class to apply when this Link is active */
  activeClassName?: string
  /** Inline styles for when this Link is active */
  activeStyle?: object
  innerRef?: Function
  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
  /** Class the link as highlighted if there is a partial match via a the `to` being prefixed to the current url */
  partiallyActive?: boolean
  /** Used to declare that this link replaces the current URL in history with the target */
  replace?: boolean
  /** Used to pass state data to the linked page.
   * The linked page will have a `location` prop containing a nested `state` object structure containing the passed data.
   */
  state?: TState
  /** The URL you want to link to */
  to: string
}
```