### PR TITLE
Fix for default scrolling behaviour after using path prefix

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import scrollToElement from "scroll-to-element";
+import { withPrefix } from "gatsby";
 import * as errorTypes from "./errors";
 
 export const isBrowser = typeof window !== "undefined";
@@ -7,7 +8,7 @@ export const isDevelopment = process.env.NODE_ENV !== "production";
 
 export function scroller(target, offset = 0) {
   scrollToElement(target, {
-    offset
+    offset,
   });
 }
 
@@ -21,7 +22,7 @@ export function handleLinkClick(to, e) {
 
   if (isBrowser && to.includes("#")) {
     const [anchorPath, anchor] = to.split("#");
-    if (window.location.pathname === anchorPath) {
+    if (window.location.pathname === withPrefix(anchorPath)) {
       e.preventDefault();
       scroller(`#${anchor}`, window.gatsby_scroll_offset);
     }


### PR DESCRIPTION
This condition `window.location.pathname === anchorPath` will not work in case you use [path prefix](https://www.gatsbyjs.org/docs/path-prefix/).

as an example:
`<AnchorLink to="/about#myId" />` will be converted into `/about` and `myId` while `window.location.pathname` will be prepended with prefix such as `/blog/about`.  
Comparison will not match and page will use default scroll behaviour. 