### PR TITLE
Bug Fix - onAnchorLinkClick not firing

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -51,7 +51,7 @@ export function handleStrippedLinkClick(to, e, onAnchorLinkClick) {
 
   if (isSamePage) {
     e.preventDefault();
-    return scroller(`#${anchor}`, window.gatsby_scroll_offset, window.gatsby_scroll_duration);
+    scroller(`#${anchor}`, window.gatsby_scroll_offset, window.gatsby_scroll_duration);
   }
 
   if (isDifferentPage) {


### PR DESCRIPTION
This PR fixes a bug where `onAnchorLinkClick` would not fire when `stripHash = true` and the anchor links to a hash on the same page.