### PR TITLE
fix: Update package.json with peer deps and repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": "Chase Ohlson <chase@chaseohlson.com>",
   "description": "Gatsby plugin for using anchor links with a Gatsby Link component.",
   "homepage": "https://github.com/brohlson/gatsby-plugin-anchor-links",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/brohlson/gatsby-plugin-anchor-links.git"
+  },
   "license": "MIT",
   "scripts": {
     "build": "babel src/ --out-dir . --ignore __tests__",
@@ -39,6 +43,9 @@
   ],
   "dependencies": {
     "scroll-to-element": "^2.0.3"
+  },
+  "peerDependencies": {
+    "gatsby": "^2.0.0 || ^3.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Hello @brohlson, Gatsby maintainer here 👋 
First and foremost, thanks for creating the plugin & maintaining it. Much appreciated!

While looking at your plugin I noticed that the `peerDependency` on `gatsby` is not set. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

I've also added the `repository` field as that'll allow the "Link to GitHub" link on `/plugins` to work properly.

I didn't test the plugin with Gatsby v2 & v3 but looking at the code I assume it works for both versions (testing it would be ideal!)

Thanks!
